### PR TITLE
possible error if cloning component registered with BaseClass

### DIFF
--- a/src/ash/core/Entity.as
+++ b/src/ash/core/Entity.as
@@ -142,8 +142,9 @@ package ash.core
 		public function clone() : Entity
 		{
 			var copy : Entity = new Entity();
-			for each( var component : Object in components )
+			for ( var classRef : * in components )
 			{
+                var component : Object   = components[classRef]
 				var names : XMLList = describeType( component ).variable.@name;
 				var componentClass : Class = component.constructor as Class;
 				var newComponent : * = new componentClass();
@@ -151,7 +152,7 @@ package ash.core
 				{
 					newComponent[key] = component[key];
 				}
-				copy.add( newComponent );
+				copy.add( newComponent , classRef);
 			}
 			return copy;
 		}

--- a/test/src/ash/core/EntityTests.as
+++ b/test/src/ash/core/EntityTests.as
@@ -171,13 +171,21 @@ package ash.core
 			assertThat( clone == entity, isFalse() );
 		}
 
-		[Test]
-		public function cloneHasChildComponent() : void
-		{
-			entity.add( new MockComponent() );
-			var clone : Entity = entity.clone();
-			assertThat( clone.has( MockComponent ), isTrue() );
-		}
+        [Test]
+        public function cloneHasChildComponent() : void
+        {
+            entity.add( new MockComponent() );
+            var clone : Entity = entity.clone();
+            assertThat( clone.has( MockComponent ), isTrue() );
+        }
+
+        [Test]
+        public function cloneHasChildComponentAsBaseType() : void
+        {
+            entity.add( new MockComponentExtended(), MockComponent );
+            var clone : Entity = entity.clone();
+            assertThat( clone.has( MockComponent ), isTrue() );
+        }
 
 		[Test]
 		public function cloneChildComponentIsNewReference() : void


### PR DESCRIPTION
adds cloneHasChildComponentAsBaseType in EntityTest and patches Entity.clone() method which now passes.

Entity.clone() was adding all cloned components against their constructor
as opposed to the class that the original was registered against

refs: "issue 15":https://github.com/richardlord/Ash/issues/15
