### PR TITLE
Suggested method EntityState.retain( ...args )

### DIFF
--- a/src/ash/fsm/EntityState.as
+++ b/src/ash/fsm/EntityState.as
@@ -1,50 +1,69 @@
 package ash.fsm
 {
-	import flash.utils.Dictionary;
+import flash.utils.Dictionary;
 
-	/**
-	 * Represents a state for an EntityStateMachine. The state contains any number of ComponentProviders which
-	 * are used to add components to the entity when this state is entered.
-	 */
-	public class EntityState
-	{
-		/**
-		 * @private
-		 */
-		internal var providers : Dictionary = new Dictionary();
+/**
+ * Represents a state for an EntityStateMachine. The state contains any number of ComponentProviders which
+ * are used to add components to the entity when this state is entered.
+ */
+public class EntityState
+{
+    /**
+     * @private
+     */
+    internal var providers:Dictionary = new Dictionary();
+    internal var retainedProviders:Dictionary = new Dictionary();
 
-		/**
-		 * Add a new ComponentMapping to this state. The mapping is a utility class that is used to
-		 * map a component type to the provider that provides the component.
-		 * 
-		 * @param type The type of component to be mapped
-		 * @return The component mapping to use when setting the provider for the component
-		 */
-		public function add( type : Class ) : StateComponentMapping
-		{
-			return new StateComponentMapping( this, type );
-		}
-		
-		/**
-		 * Get the ComponentProvider for a particular component type.
-		 * 
-		 * @param type The type of component to get the provider for
-		 * @return The ComponentProvider
-		 */
-		public function get( type : Class ) : IComponentProvider
-		{
-			return providers[ type ];
-		}
-		
-		/**
-		 * To determine whether this state has a provider for a specific component type.
-		 * 
-		 * @param type The type of component to look for a provider for
-		 * @return true if there is a provider for the given type, false otherwise
-		 */
-		public function has( type : Class ) : Boolean
-		{
-			return providers[ type ] != null;
-		}
-	}
+    /**
+     * Add a new ComponentMapping to this state. The mapping is a utility class that is used to
+     * map a component type to the provider that provides the component.
+     *
+     * @param type The type of component to be mapped
+     * @return The component mapping to use when setting the provider for the component
+     */
+    public function add( type:Class ):StateComponentMapping
+    {
+        return new StateComponentMapping( this, type );
+    }
+
+    /**
+     * Get the ComponentProvider for a particular component type.
+     *
+     * @param type The type of component to get the provider for
+     * @return The ComponentProvider
+     */
+    public function get( type:Class ):IComponentProvider
+    {
+        return providers[ type ];
+    }
+
+    /**
+     * To determine whether this state has a provider for a specific component type.
+     *
+     * @param type The type of component to look for a provider for
+     * @return true if there is a provider for the given type, false otherwise
+     */
+    public function has( type:Class ):Boolean
+    {
+        return providers[ type ] != null;
+    }
+
+    /**
+     * Specifies the types of component providers to be retained from the previous
+     * state. This allows for lazier creation of states which share most components
+     *
+     * @param args The type of component to be retained
+     * @return The EntityState to enable method chaining
+     */
+    public function retain( ...args ):EntityState
+    {
+        for each (var c:Class in args){
+            retainedProviders[c] = true;
+        }
+
+        return this;
+    }
+
+
+}
 }

--- a/src/ash/fsm/EntityStateMachine.as
+++ b/src/ash/fsm/EntityStateMachine.as
@@ -91,7 +91,7 @@ package ash.fsm
 					type = Class( t );
 					var other : IComponentProvider = toAdd[ type ];
 
-					if ( other && other.identifier == currentState.providers[ type ].identifier )
+					if ( newState.retainedProviders[t] || other && other.identifier == currentState.providers[ type ].identifier )
 					{
 						delete toAdd[ type ];
 					}

--- a/test/src/ash/fsm/EntityStateMachineTests.as
+++ b/test/src/ash/fsm/EntityStateMachineTests.as
@@ -99,25 +99,45 @@ package ash.fsm
 			assertThat( entity.get( MockComponent ), sameInstance( component1 ) );
 		}
 
-		[Test]
-		public function enterSecondStateRemovesDifferentComponentsOfSameType() : void
-		{
-			var state1 : EntityState = new EntityState();
-			var component1 : MockComponent = new MockComponent();
-			state1.add( MockComponent ).withInstance( component1 );
-			fsm.addState( "test1", state1 );
-			fsm.changeState( "test1" );
+        [Test]
+        public function enterSecondStateRemovesDifferentComponentsOfSameType() : void
+        {
+            var state1 : EntityState = new EntityState();
+            var component1 : MockComponent = new MockComponent();
+            state1.add( MockComponent ).withInstance( component1 );
+            fsm.addState( "test1", state1 );
+            fsm.changeState( "test1" );
 
-			var state2 : EntityState = new EntityState();
-			var component3 : MockComponent = new MockComponent();
-			var component2 : MockComponent2 = new MockComponent2();
-			state2.add( MockComponent ).withInstance( component3 );
-			state2.add( MockComponent2 ).withInstance( component2 );
-			fsm.addState( "test2", state2 );
-			fsm.changeState( "test2" );
+            var state2 : EntityState = new EntityState();
+            var component3 : MockComponent = new MockComponent();
+            var component2 : MockComponent2 = new MockComponent2();
+            state2.add( MockComponent ).withInstance( component3 );
+            state2.add( MockComponent2 ).withInstance( component2 );
+            fsm.addState( "test2", state2 );
+            fsm.changeState( "test2" );
 
-			assertThat( entity.get( MockComponent ), sameInstance( component3 ) );
-		}
+            assertThat( entity.get( MockComponent ), sameInstance( component3 ) );
+        }
+
+        [Test]
+        public function retainInhibitsRemovalOfSpecifiedProviderClass() : void
+        {
+            var state1 : EntityState = new EntityState();
+            var component1 : MockComponent = new MockComponent();
+            state1.add( MockComponent ).withInstance( component1 );
+            fsm.addState( "test1", state1 );
+            fsm.changeState( "test1" );
+
+            var state2 : EntityState = new EntityState();
+            var component2 : MockComponent2 = new MockComponent2();
+
+            state2.add( MockComponent2 ).withInstance( component2 );
+            state2.retain(MockComponent)
+            fsm.addState( "test2", state2 );
+            fsm.changeState( "test2" );
+
+            assertThat( entity.get( MockComponent ), sameInstance( component1 ) );
+        }
 
 		private static function failIfCalled( ...args ) : void
 		{

--- a/test/src/ash/fsm/EntityStateTests.as
+++ b/test/src/ash/fsm/EntityStateTests.as
@@ -1,70 +1,87 @@
 package ash.fsm
 {
-	import org.hamcrest.assertThat;
-	import org.hamcrest.object.equalTo;
-	import org.hamcrest.object.instanceOf;
+import org.hamcrest.assertThat;
+import org.hamcrest.object.equalTo;
+import org.hamcrest.object.instanceOf;
+import org.hamcrest.object.isTrue;
+import org.hamcrest.object.strictlyEqualTo;
 
-	public class EntityStateTests
-	{
-		private var state : EntityState;
+public class EntityStateTests
+{
+    private var state:EntityState;
 
-		[Before]
-		public function createState() : void
-		{
-			state = new EntityState();
-		}
+    [Before]
+    public function createState():void
+    {
+        state = new EntityState();
+    }
 
-		[After]
-		public function clearState() : void
-		{
-			state = null;
-		}
-		
-		[Test]
-		public function addWithNoQualifierCreatesTypeProvider() : void
-		{
-			state.add( MockComponent );
-			var provider : IComponentProvider = state.providers[MockComponent];
-			assertThat( provider, instanceOf( ComponentTypeProvider ) );
-			assertThat( provider.getComponent(), instanceOf( MockComponent ) );
-		}
-		
-		[Test]
-		public function addWithTypeQualifierCreatesTypeProvider() : void
-		{
-			state.add( MockComponent ).withType( MockComponent2 );
-			var provider : IComponentProvider = state.providers[MockComponent];
-			assertThat( provider, instanceOf( ComponentTypeProvider ) );
-			assertThat( provider.getComponent(), instanceOf( MockComponent2 ) );
-		}
-		
-		[Test]
-		public function addWithInstanceQualifierCreatesInstanceProvider() : void
-		{
-			var component : MockComponent = new MockComponent();
-			state.add( MockComponent ).withInstance( component );
-			var provider : IComponentProvider = state.providers[MockComponent];
-			assertThat( provider, instanceOf( ComponentInstanceProvider ) );
-			assertThat( provider.getComponent(), equalTo( component ) );
-		}
-		
-		[Test]
-		public function addWithSingletonQualifierCreatesSingletonProvider() : void
-		{
-			state.add( MockComponent ).withSingleton( MockComponent );
-			var provider : IComponentProvider = state.providers[MockComponent];
-			assertThat( provider, instanceOf( ComponentSingletonProvider ) );
-			assertThat( provider.getComponent(), instanceOf( MockComponent ) );
-		}
-	}
+    [After]
+    public function clearState():void
+    {
+        state = null;
+    }
+
+    [Test]
+    public function addWithNoQualifierCreatesTypeProvider():void
+    {
+        state.add( MockComponent );
+        var provider:IComponentProvider = state.providers[MockComponent];
+        assertThat( provider, instanceOf( ComponentTypeProvider ) );
+        assertThat( provider.getComponent(), instanceOf( MockComponent ) );
+    }
+
+    [Test]
+    public function addWithTypeQualifierCreatesTypeProvider():void
+    {
+        state.add( MockComponent ).withType( MockComponent2 );
+        var provider:IComponentProvider = state.providers[MockComponent];
+        assertThat( provider, instanceOf( ComponentTypeProvider ) );
+        assertThat( provider.getComponent(), instanceOf( MockComponent2 ) );
+    }
+
+    [Test]
+    public function addWithInstanceQualifierCreatesInstanceProvider():void
+    {
+        var component:MockComponent = new MockComponent();
+        state.add( MockComponent ).withInstance( component );
+        var provider:IComponentProvider = state.providers[MockComponent];
+        assertThat( provider, instanceOf( ComponentInstanceProvider ) );
+        assertThat( provider.getComponent(), equalTo( component ) );
+    }
+
+    [Test]
+    public function addWithSingletonQualifierCreatesSingletonProvider():void
+    {
+        state.add( MockComponent ).withSingleton( MockComponent );
+        var provider:IComponentProvider = state.providers[MockComponent];
+        assertThat( provider, instanceOf( ComponentSingletonProvider ) );
+        assertThat( provider.getComponent(), instanceOf( MockComponent ) );
+    }
+
+    [Test]
+    public function retainClassAddedToMap():void
+    {
+        state.retain( MockComponent )
+        assertThat( state.retainedProviders[MockComponent], isTrue() );
+    }
+
+    [Test]
+    public function retainReturnsSelf():void
+    {
+
+        assertThat(state.retain( MockComponent ), strictlyEqualTo( state) );
+    }
+
+}
 }
 
 class MockComponent
 {
-	public var value : int;
+    public var value:int;
 }
 
 class MockComponent2 extends MockComponent
 {
-	
+
 }


### PR DESCRIPTION
This is a suggestion to be able to explicitly declare which components to keep from the previous state. 

this, for example:

``` actionscript
fsm.createState( "locked" )
                .retain( Enemy, Position, PositionAdjustment, Motion, Collision, Damage, Twease, Threat )
                .add( TargetLock ).withType( TargetLock )
                .add( Display ).withInstance( new Display( lockedDisplay, entity.name ) )
```

allows the locked state to keep all the components declared, without verbosely having to re-define them and pass the same instance.

this doesn't affect the current way, and I can't think of any further implications that might arise.

What do you think?

BTW am really enjoying working with Ash it is a pleasure to use.
