### PR TITLE
adds wrapper methods to EntityStateMachine to add directly to Entity

### DIFF
--- a/src/ash/fsm/EntityComponentMapping.as
+++ b/src/ash/fsm/EntityComponentMapping.as
@@ -1,0 +1,50 @@
+package ash.fsm
+{
+import ash.core.Entity;
+
+/**
+ * Used by the EntityStateMachine class to create the mappings of components directly on the Entity via a fluent interface.
+ */
+internal class EntityComponentMapping
+{
+
+    /**
+     * Used internally, the constructor creates a component mapping directly on the Entity
+     *
+     * @param entity The Entity on which to map components
+     * @param type The component type for the mapping
+     */
+    public function EntityComponentMapping( entity:Entity, type:Class )
+    {
+        this.entity = entity;
+        componentType = type;
+    }
+
+    private var componentType:Class;
+    private var entity:Entity;
+
+    /**
+     * Creates a mapping for the component type to a specific component instance.
+     *
+     * @param component The component instance to use for the mapping
+     * @return This ComponentMapping, so more modifications can be applied
+     */
+    public function withInstance( component:* ):EntityComponentMapping
+    {
+        entity.add( component, componentType );
+        return this;
+    }
+
+    /**
+     * Creates another EntityComponentMapping wrapping the same Entity, so a fluent interface
+     * can be used when configuring EntityStateMachine
+     *
+     * @param type The type of component to add a mapping to the state for
+     * @return The new ComponentMapping for that type
+     */
+    public function add( type:Class ):EntityComponentMapping
+    {
+        return new EntityComponentMapping( entity, type );
+    }
+}
+}

--- a/src/ash/fsm/EntityStateMachine.as
+++ b/src/ash/fsm/EntityStateMachine.as
@@ -112,5 +112,10 @@ package ash.fsm
 			}
 			currentState = newState;
 		}
-	}
+
+        public function add( type:Class ):EntityComponentMapping
+        {
+            return new EntityComponentMapping(entity, type);
+        }
+    }
 }

--- a/test/src/ash/AllTests.as
+++ b/test/src/ash/AllTests.as
@@ -1,36 +1,38 @@
 package ash
 {
-	import ash.core.ComponentMatchingFamilyTests;
-	import ash.core.EntityTests;
-	import ash.core.EngineAndFamilyIntegrationTests;
-	import ash.core.EngineTests;
-	import ash.core.NodeListTests;
-	import ash.core.SystemTests;
-	import ash.fsm.ComponentInstanceProviderTests;
-	import ash.fsm.ComponentSingletonProviderTests;
-	import ash.fsm.ComponentTypeProviderTests;
-	import ash.fsm.EntityStateMachineTests;
-	import ash.fsm.EntityStateTests;
-	import ash.signals.SignalTest;
-	import ash.tools.ComponentPoolTest;
-	import ash.tools.ListIteratingSystemTest;
+import ash.core.ComponentMatchingFamilyTests;
+import ash.core.EngineAndFamilyIntegrationTests;
+import ash.core.EngineTests;
+import ash.core.EntityTests;
+import ash.core.NodeListTests;
+import ash.core.SystemTests;
+import ash.fsm.AddComponentDirectlyTests;
+import ash.fsm.ComponentInstanceProviderTests;
+import ash.fsm.ComponentSingletonProviderTests;
+import ash.fsm.ComponentTypeProviderTests;
+import ash.fsm.EntityStateMachineTests;
+import ash.fsm.EntityStateTests;
+import ash.signals.SignalTest;
+import ash.tools.ComponentPoolTest;
+import ash.tools.ListIteratingSystemTest;
 
-	[Suite]
-	public class AllTests
-	{
-		public var entityTests : EntityTests;
-		public var nodeListTests : NodeListTests;
-		public var systemTests : SystemTests;
-		public var engineTests : EngineTests;
-		public var familyTests : ComponentMatchingFamilyTests;
-		public var engineAndFamilyTests : EngineAndFamilyIntegrationTests;
-		public var signalTests : SignalTest;
-		public var componentPoolTest : ComponentPoolTest;
-		public var listIteratingSystemTest : ListIteratingSystemTest;
-		public var entityStateMachineTests : EntityStateMachineTests;
-		public var entityStateTests : EntityStateTests;
-		public var componentInstanceProviderTests : ComponentInstanceProviderTests;
-		public var componentTypeProviderTests : ComponentTypeProviderTests;
-		public var componentSingletonProviderTests : ComponentSingletonProviderTests;
-	}
+[Suite]
+public class AllTests
+{
+    public var entityTests:EntityTests;
+    public var nodeListTests:NodeListTests;
+    public var systemTests:SystemTests;
+    public var engineTests:EngineTests;
+    public var familyTests:ComponentMatchingFamilyTests;
+    public var engineAndFamilyTests:EngineAndFamilyIntegrationTests;
+    public var signalTests:SignalTest;
+    public var componentPoolTest:ComponentPoolTest;
+    public var listIteratingSystemTest:ListIteratingSystemTest;
+    public var entityStateMachineTests:EntityStateMachineTests;
+    public var entityStateTests:EntityStateTests;
+    public var componentInstanceProviderTests:ComponentInstanceProviderTests;
+    public var componentTypeProviderTests:ComponentTypeProviderTests;
+    public var componentSingletonProviderTests:ComponentSingletonProviderTests
+    public var addComponentDirectlyTests:AddComponentDirectlyTests;
+}
 }

--- a/test/src/ash/fsm/AddComponentDirectlyTests.as
+++ b/test/src/ash/fsm/AddComponentDirectlyTests.as
@@ -1,0 +1,57 @@
+package ash.fsm
+{
+import ash.core.Entity;
+
+import asunit.framework.IAsync;
+
+import org.hamcrest.assertThat;
+import org.hamcrest.object.isTrue;
+
+public class AddComponentDirectlyTests
+{
+    [Inject]
+    public var async:IAsync;
+    private var fsm:EntityStateMachine;
+    private var entity:Entity;
+
+    [Before]
+    public function createState():void
+    {
+        entity = new Entity();
+        fsm = new EntityStateMachine( entity );
+        trace( ":KJH:KJH" );
+    }
+
+    [After]
+    public function clearState():void
+    {
+        entity = null;
+        fsm = null;
+    }
+
+    [Test]
+    public function addingComponentWithTypeAddsDirectlyToEntity():void
+    {
+        fsm.add( MockComponent ).withInstance( new MockComponent );
+        assertThat( entity.has( MockComponent ), isTrue() );
+    }
+
+    [Test]
+    public function addingComponentWithSuperTypeAddsDirectlyToEntity():void
+    {
+        fsm.add( MockComponent ).withInstance( new MockComponent2 );
+        assertThat( entity.has( MockComponent ), isTrue() );
+    }
+
+}
+}
+
+class MockComponent
+{
+    public var value:int;
+}
+
+class MockComponent2 extends MockComponent
+{
+
+}


### PR DESCRIPTION
This allows a standardised fluent api for configuring Entities and their States 

So instead of adding components that will be permanently registered with the Entity directly, using the add( component:*, type:Class = null) method, all components can be added onto the EntityStateMachine using similar fluent api.

Perhaps add() isn't the best name for the method, I have also considered

1) addPermanently() 
2) addDirectly()

cheers
